### PR TITLE
pr 103

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.1/schema.json",
   "files": {
-    "includes": ["**", "!**/node_modules", "!**/content.d.ts", "!**/.astro", "!**/dist"]
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/content.d.ts",
+      "!**/.astro",
+      "!**/dist",
+      "!**/.claude"
+    ]
   },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -1,6 +1,7 @@
 ---
 import Tag from '../components/Tag.astro';
 import DefaultLayout from '../layouts/Default.astro';
+
 // interface Props {
 //   frontmatter: {
 //     title: string;


### PR DESCRIPTION
- **Bump astro from 5.5.4 to 5.7.4**
- **Bump @astrojs/tailwind from 6.0.1 to 6.0.2**
- **Bump astro from 5.7.4 to 5.9.3**
- **init claude**
- **Bump @astrojs/mdx from 4.2.0 to 4.3.3**
- **Bump sharp from 0.33.5 to 0.34.3**
- **Bump @astrojs/sitemap from 3.2.1 to 3.5.1**
- **Bump @biomejs/biome from 1.9.4 to 2.2.2**
- **Bump the npm_and_yarn group with 2 updates**
- **Bump @biomejs/biome from 2.2.2 to 2.2.3**
- **Bump prettier from 3.5.3 to 3.6.2**
- **Bump @astrojs/rss from 4.0.11 to 4.0.12**
- **Bump @biomejs/biome from 2.2.3 to 2.2.4**
- **Bump @astrojs/mdx from 4.3.3 to 4.3.5**
- **Bump sharp from 0.34.3 to 0.34.4**
- **Bump astro from 5.13.1 to 5.14.4**
- **Bump @astrojs/mdx from 4.3.5 to 4.3.7**
- **Bump @astrojs/sitemap from 3.5.1 to 3.6.0**
- **Bump lint-staged from 15.5.0 to 16.2.4**
- **Bump @biomejs/biome from 2.2.4 to 2.2.6**
- **Bump tailwindcss from 3.4.17 to 3.4.18**
- **Bump vite in the npm_and_yarn group across 1 directory**
- **Bump astro from 5.14.4 to 5.14.6**
- **Bump @astrojs/mdx from 4.3.7 to 4.3.8**
- **Bump @biomejs/biome from 2.2.6 to 2.3.1**
- **Bump @astrojs/rss from 4.0.12 to 4.0.13**
- **Bump lint-staged from 16.2.4 to 16.2.6**
- **Migrate biome.json to version 2.3.1 and fix lint configuration**
- **fix lint**
